### PR TITLE
Rename ~/Js/ to ~/Scripts/

### DIFF
--- a/build/Build-Release.ps1
+++ b/build/Build-Release.ps1
@@ -42,7 +42,7 @@ $SolutionInfoPath = Join-Path -Path $SolutionRoot -ChildPath "SolutionInfo.cs"
 
 # Set the copyright
 $NowYear = (Get-Date).year
-$Copyright = "Copyright © Shannon Deminick $NowYear"
+$Copyright = "Copyright Â© Shannon Deminick $NowYear"
 
 (gc -Path $SolutionInfoPath) `
 	-replace "(?<=AssemblyCopyright\(`").*(?=`"\))", "$Copyright" |
@@ -91,7 +91,7 @@ $AppCodeDestFolder = Join-Path -Path $ReleaseFolder -ChildPath "App_Start";
 Copy-Item "$AppCodeFolder\UmbracoIdentityStartup.cs" -Destination (New-Item ($AppCodeDestFolder) -Type directory);
 
 # COPY THE JS OVER
-Copy-Item "$SolutionRoot\UmbracoIdentity.Web\Js\" -Destination $ReleaseFolder -recurse -Container -Filter *.js;
+Copy-Item "$SolutionRoot\UmbracoIdentity.Web\Scripts\" -Destination $ReleaseFolder -recurse -Container -Filter *.js;
 
 # Remove the DEGUB code from the startup class since we don't want to ship that
 # NOTE: We're using the .Net constructs to do this because I could not get this to work with the powershell regex even with the (?s) prefix switch

--- a/src/UmbracoIdentity.Web/App_Code/UmbracoIdentityStartup.cs
+++ b/src/UmbracoIdentity.Web/App_Code/UmbracoIdentityStartup.cs
@@ -11,7 +11,7 @@ using UmbracoIdentity.Web.Models.UmbracoIdentity;
 using UmbracoIdentity.Web;
 using Owin;
 
-[assembly: OwinStartup(typeof(UmbracoIdentityStartup))]
+[assembly: OwinStartup("UmbracoIdentityStartup", typeof(UmbracoIdentityStartup))]
 
 namespace UmbracoIdentity.Web
 {


### PR DESCRIPTION
I'm new to PS scripts.

I'm a bit concerned about this bit "Copy-Item "$SolutionRoot\UmbracoIdentity.Web\JS"

When or where are the scripts?