### PR TITLE
Extended membership provider configuration properties

### DIFF
--- a/src/UmbracoIdentity/FrontEndCookieAuthenticationOptions.cs
+++ b/src/UmbracoIdentity/FrontEndCookieAuthenticationOptions.cs
@@ -26,5 +26,12 @@ namespace UmbracoIdentity
             CookieSecure = globalSettings.UseHttps ? CookieSecureOption.Always : CookieSecureOption.SameAsRequest;
             CookiePath = "/";
         }
+
+        [Obsolete("Use FrontEndCookieAuthenticationOptions constructor with extended parameters")]
+        public FrontEndCookieAuthenticationOptions(FrontEndCookieManager frontEndCookieManager)
+        {
+            CookieManager = frontEndCookieManager;
+            AuthenticationType = DefaultAuthenticationTypes.ApplicationCookie;
+        }
     }
 }

--- a/src/UmbracoIdentity/FrontEndCookieAuthenticationOptions.cs
+++ b/src/UmbracoIdentity/FrontEndCookieAuthenticationOptions.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNet.Identity;
 using Microsoft.Owin.Security.Cookies;
+using System;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Configuration.UmbracoSettings;
 
 namespace UmbracoIdentity
 {
@@ -8,10 +11,20 @@ namespace UmbracoIdentity
     /// </summary>
     public class FrontEndCookieAuthenticationOptions : CookieAuthenticationOptions
     {
-        public FrontEndCookieAuthenticationOptions(FrontEndCookieManager frontEndCookieManager)
+        public FrontEndCookieAuthenticationOptions(
+            FrontEndCookieManager frontEndCookieManager,
+            ISecuritySection securitySection,
+            IGlobalSettings globalSettings)
         {
             CookieManager = frontEndCookieManager;
             AuthenticationType = DefaultAuthenticationTypes.ApplicationCookie;
+            SlidingExpiration = true;
+            ExpireTimeSpan = TimeSpan.FromMinutes(globalSettings.TimeOutInMinutes);
+            CookieDomain = securitySection.AuthCookieDomain;
+            CookieName = securitySection.AuthCookieName + "_MEMBERS";
+            CookieHttpOnly = true;
+            CookieSecure = globalSettings.UseHttps ? CookieSecureOption.Always : CookieSecureOption.SameAsRequest;
+            CookiePath = "/";
         }
     }
 }

--- a/src/UmbracoIdentity/IdentityEnabledMembersMembershipProvider.cs
+++ b/src/UmbracoIdentity/IdentityEnabledMembersMembershipProvider.cs
@@ -1,5 +1,5 @@
 using System.Collections.Specialized;
-using System.Web.Configuration;
+using System.Text;
 using System.Web.Security;
 using Umbraco.Web.Security.Providers;
 
@@ -55,5 +55,15 @@ namespace UmbracoIdentity
             PasswordRequiresLowercase = config.GetValue("passwordRequiresLowercase", false);
             PasswordRequiresUppercase = config.GetValue("passwordRequiresUppercase", false);
         }
-    }
+
+		public override string ToString()
+		{
+			var result = base.ToString();
+			var sb = new StringBuilder(result);
+			sb.AppendLine("_passwordRequiresDigit=" + PasswordRequiresDigit);
+			sb.AppendLine("_passwordRequiresLowercase=" + PasswordRequiresLowercase);
+			sb.AppendLine("_passwordRequiresUppercase=" + PasswordRequiresUppercase);
+			return sb.ToString();
+		}
+	}
 }

--- a/src/UmbracoIdentity/IdentityEnabledMembersMembershipProvider.cs
+++ b/src/UmbracoIdentity/IdentityEnabledMembersMembershipProvider.cs
@@ -13,6 +13,13 @@ namespace UmbracoIdentity
     public class IdentityEnabledMembersMembershipProvider : MembersMembershipProvider
     {
         /// <summary>
+        /// Gets a value indicating whether member usernames are only alphanumeric.
+        /// </summary>
+        /// <value></value>
+        /// <returns>true if a usernames are only alphanumeric; otherwise, false. The default is false.</returns>
+        public bool AllowOnlyAlphanumericUserNames { get; private set; }
+
+        /// <summary>
         /// Gets a value indicating whether passwords require a digit.
         /// </summary>
         /// <value></value>
@@ -51,6 +58,7 @@ namespace UmbracoIdentity
         {
             base.Initialize(name, config);
 
+            AllowOnlyAlphanumericUserNames = config.GetValue("allowOnlyAlphanumericUserNames", false);
             PasswordRequiresDigit = config.GetValue("passwordRequiresDigit", false);
             PasswordRequiresLowercase = config.GetValue("passwordRequiresLowercase", false);
             PasswordRequiresUppercase = config.GetValue("passwordRequiresUppercase", false);
@@ -60,6 +68,7 @@ namespace UmbracoIdentity
 		{
 			var result = base.ToString();
 			var sb = new StringBuilder(result);
+			sb.AppendLine("_allowOnlyAlphanumericUserNames=" + AllowOnlyAlphanumericUserNames);
 			sb.AppendLine("_passwordRequiresDigit=" + PasswordRequiresDigit);
 			sb.AppendLine("_passwordRequiresLowercase=" + PasswordRequiresLowercase);
 			sb.AppendLine("_passwordRequiresUppercase=" + PasswordRequiresUppercase);

--- a/src/UmbracoIdentity/IdentityEnabledMembersMembershipProvider.cs
+++ b/src/UmbracoIdentity/IdentityEnabledMembersMembershipProvider.cs
@@ -1,3 +1,5 @@
+using System.Collections.Specialized;
+using System.Web.Configuration;
 using System.Web.Security;
 using Umbraco.Web.Security.Providers;
 
@@ -10,6 +12,27 @@ namespace UmbracoIdentity
     /// </summary>
     public class IdentityEnabledMembersMembershipProvider : MembersMembershipProvider
     {
+        /// <summary>
+        /// Gets a value indicating whether passwords require a digit.
+        /// </summary>
+        /// <value></value>
+        /// <returns>true if a password requires a digit; otherwise, false. The default is false.</returns>
+        public bool PasswordRequiresDigit { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether passwords require a lowercase character.
+        /// </summary>
+        /// <value></value>
+        /// <returns>true if a password requires a lowercase character; otherwise, false. The default is false.</returns>
+        public bool PasswordRequiresLowercase { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether passwords require a uppercase character.
+        /// </summary>
+        /// <value></value>
+        /// <returns>true if a password requires a uppercase character; otherwise, false. The default is false.</returns>
+        public bool PasswordRequiresUppercase { get; private set; }
+
         public new string HashPasswordForStorage(string password)
         {
             string salt;
@@ -23,5 +46,14 @@ namespace UmbracoIdentity
         }
 
         public override MembershipPasswordFormat PasswordFormat => MembershipPasswordFormat.Hashed;
+
+        public override void Initialize(string name, NameValueCollection config)
+        {
+            base.Initialize(name, config);
+
+            PasswordRequiresDigit = config.GetValue("passwordRequiresDigit", false);
+            PasswordRequiresLowercase = config.GetValue("passwordRequiresLowercase", false);
+            PasswordRequiresUppercase = config.GetValue("passwordRequiresUppercase", false);
+        }
     }
 }

--- a/src/UmbracoIdentity/NameValueCollectionExtensions.cs
+++ b/src/UmbracoIdentity/NameValueCollectionExtensions.cs
@@ -5,6 +5,9 @@ using Umbraco.Core;
 
 namespace UmbracoIdentity
 {
+    /// <summary>
+    /// Duplicate of internal Umbraco.Core.NameValueCollectionExtensions
+    /// </summary>
     internal static class NameValueCollectionExtensions
     {
         public static IEnumerable<KeyValuePair<string, string>> AsEnumerable(this NameValueCollection nvc)

--- a/src/UmbracoIdentity/NameValueCollectionExtensions.cs
+++ b/src/UmbracoIdentity/NameValueCollectionExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using Umbraco.Core;
+
+namespace UmbracoIdentity
+{
+    internal static class NameValueCollectionExtensions
+    {
+        public static IEnumerable<KeyValuePair<string, string>> AsEnumerable(this NameValueCollection nvc)
+        {
+            foreach (string key in nvc.AllKeys)
+            {
+                yield return new KeyValuePair<string, string>(key, nvc[key]);
+            }
+        }
+
+        public static bool ContainsKey(this NameValueCollection collection, string key)
+        {
+            return collection.Keys.Cast<object>().Any(k => (string)k == key);
+        }
+
+        public static T GetValue<T>(this NameValueCollection collection, string key, T defaultIfNotFound)
+        {
+            if (collection.ContainsKey(key) == false)
+            {
+                return defaultIfNotFound;
+            }
+
+            var val = collection[key];
+            if (val == null)
+            {
+                return defaultIfNotFound;
+            }
+
+            var result = val.TryConvertTo<T>();
+
+            return result.Success ? result.Result : defaultIfNotFound;
+        }
+    }
+}

--- a/src/UmbracoIdentity/UmbracoIdentity.csproj
+++ b/src/UmbracoIdentity/UmbracoIdentity.csproj
@@ -271,6 +271,7 @@
     <Compile Include="Models\IdentityMemberClaim.cs" />
     <Compile Include="Models\IdentityMemberRole.cs" />
     <Compile Include="Models\IdentityMemberLogin.cs" />
+    <Compile Include="NameValueCollectionExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReflectionHelper.cs" />
     <Compile Include="Models\UmbracoIdentityMember.cs" />

--- a/src/UmbracoIdentity/UmbracoMembersUserManager.cs
+++ b/src/UmbracoIdentity/UmbracoMembersUserManager.cs
@@ -143,8 +143,8 @@ namespace UmbracoIdentity
             // Configure validation logic for usernames
             manager.UserValidator = new UserValidator<TUser, int>(manager)
             {
-                AllowOnlyAlphanumericUserNames = false,
-                RequireUniqueEmail = true
+                AllowOnlyAlphanumericUserNames = provider.AllowOnlyAlphanumericUserNames,
+                RequireUniqueEmail = provider.RequiresUniqueEmail
             };
 
             // Configure validation logic for passwords

--- a/src/UmbracoIdentity/UmbracoMembersUserManager.cs
+++ b/src/UmbracoIdentity/UmbracoMembersUserManager.cs
@@ -152,9 +152,9 @@ namespace UmbracoIdentity
             {
                 RequiredLength = provider.MinRequiredPasswordLength,
                 RequireNonLetterOrDigit = provider.MinRequiredNonAlphanumericCharacters > 0,
-                RequireDigit = false,
-                RequireLowercase = false,
-                RequireUppercase = false
+                RequireDigit = provider.PasswordRequiresDigit,
+                RequireLowercase = provider.PasswordRequiresLowercase,
+                RequireUppercase = provider.PasswordRequiresUppercase
             };
 
             //use a custom hasher based on our membership provider
@@ -182,6 +182,7 @@ namespace UmbracoIdentity
             {
                 manager.UserTokenProvider = new DataProtectorTokenProvider<TUser, int>(dataProtectionProvider.Create("ASP.NET Identity"));
             }
+
             return manager;
         }
         


### PR DESCRIPTION
Relates to #101 

I've added configuration properties that cover the basic properties of the UserValidator and the PasswordValidator.

- "allowOnlyAlphanumericUserNames" sets UmbracoMembersUserManager.UserValidator.AllowOnlyAlphanumericUserNames
- "requiresUniqueEmail" sets UmbracoMembersUserManager.UserValidator.RequiresUniqueEmail (this configuration property already existed in the inherited base)
- "passwordRequiresDigit" sets UmbracoMembersUserManager.PasswordValidator.RequireDigit
- "passwordRequiresLowercase" sets UmbracoMembersUserManager.PasswordValidator.RequireLowercase
- "passwordRequiresUppercase" sets UmbracoMembersUserManager.PasswordValidator.RequireUppercase

e.g.
`<add name="UmbracoMembershipProvider" type="UmbracoIdentity.IdentityEnabledMembersMembershipProvider" passwordRequiresDigit="true" passwordRequiresUppercase="true" ...  />`

I also assigned the default cookie options in the FrontEndCookieAuthenticationOptions to reflect the existing app settings and security settings from the global configurations, like secure flag, expiration time, domain etc. Not sure if this was one step too far?



