### PR TITLE
Added missing "using UmbracoIdentity;"

### DIFF
--- a/src/UmbracoIdentity.Web/App_Start/Models/UmbracoIdentity/UserPasswordModel.cs
+++ b/src/UmbracoIdentity.Web/App_Start/Models/UmbracoIdentity/UserPasswordModel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using Umbraco.Web.Composing;
 using Umbraco.Core;
 using Microsoft.AspNet.Identity;
+using UmbracoIdentity;
 
 namespace UmbracoIdentity.Web.Models.UmbracoIdentity
 {


### PR DESCRIPTION
This file was missing the reference to UmbracoIdentity.
This resulted in a compilation error.

Adding 
`using UmbracoIdentity;`
solves that issue